### PR TITLE
Add Raw Test Routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+- Create additional raw test routes to keep tests at modular level.
 
-2.0.0-RC.0 - (Janurary 26, 2018)
+### Fixed
+- Set the `hideBidiUtility` default prop to be false as mapped to the site config
+
+2.0.0-RC.0 - (January 26, 2018)
 ----------
-
 ### Major Version Bump
 Terra-site has been enhanced from a site that displays docs, examples and tests of component packages contained
 within the terra-core repository to be a package that dynamically builds a react-hash-routed site based on site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 - Create additional raw test routes to keep tests at modular level.
+- In the generate-component-config, sort the found files to be in alphabetical order for navigation
 
 ### Fixed
 - Set the `hideBidiUtility` default prop to be false as mapped to the site config

--- a/scripts/generate-component-config/generate-component-config.js
+++ b/scripts/generate-component-config/generate-component-config.js
@@ -66,6 +66,7 @@ const repositoryName = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), 'p
 const outputPath = commander.output;
 const outputPathDepth = outputPath === './' ? 0 : outputPath.replace('./', '').split(path.sep).length;
 
+foundFiles.sort();
 const { packageConfigs, imports } = buildComponentConfig(foundFiles, repositoryName, outputPathDepth);
 
 writeComponentConfig(packageConfigs, imports, commander.output, commander.pages, commander.tests);

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -73,7 +73,7 @@ const defaultProps = {
   appTitle: appConfig.title,
   appSubtitle: appConfig.subtitle,
   appLogoSrc: appConfig.logoSrc,
-  hideBidiUtility: appConfig.bidirectional,
+  hideBidiUtility: !appConfig.bidirectional,
   defaultDir: appConfig.defualtDirection,
   defaultTheme: appConfig.defaultTheme,
   themes: appConfig.themes,
@@ -115,23 +115,26 @@ class App extends React.Component {
       appLogo = (<Image variant="rounded" src={this.props.appLogoSrc} height="26px" width="26px" isFluid />);
     }
 
-    const applicationHeader = (
-      <ApplicationHeader
-        title={this.props.appTitle}
-        subtitle={this.props.appSubtitle}
-        logo={appLogo}
-        locale={this.state.locale}
-        locales={this.props.locales}
-        onLocaleChange={this.handleLocaleChange}
-        hideBidiUtility={this.props.hideBidiUtility}
-        dir={this.state.dir}
-        onDirChange={this.handleBidiChange}
-        theme={this.state.theme}
-        themes={Object.keys(this.props.themes)}
-        onThemeChange={this.handleThemeChange}
-        navigation={matchPath(this.props.location.pathname, this.props.rootPath) ? this.props.navigation : null}
-      />
-    );
+    let applicationHeader;
+    if (!matchPath(this.props.location.pathname, '/raw/tests')) {
+      applicationHeader = (
+        <ApplicationHeader
+          title={this.props.appTitle}
+          subtitle={this.props.appSubtitle}
+          logo={appLogo}
+          locale={this.state.locale}
+          locales={this.props.locales}
+          onLocaleChange={this.handleLocaleChange}
+          hideBidiUtility={this.props.hideBidiUtility}
+          dir={this.state.dir}
+          onDirChange={this.handleBidiChange}
+          theme={this.state.theme}
+          themes={Object.keys(this.props.themes)}
+          onThemeChange={this.handleThemeChange}
+          navigation={matchPath(this.props.location.pathname, this.props.rootPath) ? this.props.navigation : null}
+        />
+      );
+    }
 
     return (
       <ThemeProvider id="site" themeName={this.props.themes[this.state.theme]} isGlobalTheme>

--- a/src/app/configureApp.jsx
+++ b/src/app/configureApp.jsx
@@ -120,6 +120,15 @@ const routeConfiguration = (siteConfig, componentConfig, placeholderSrc, readMeC
       component: buildComponent(contentComponent, componentProps),
     };
 
+    // build raw test pages to maintain modular testing
+    if (exampleType === 'tests') {
+      const rawComponentProps = Object.assign({}, componentProps, { pathRoot: '/raw/tests'});
+      content['/raw/tests'] = {
+        path: '/raw/tests',
+        component: buildComponent(contentComponent, rawComponentProps),
+      };
+    }
+
     // build content configuration
     let menuComponent = ComponentsMenu;
     if (link.menuComponent) {

--- a/src/app/configureApp.jsx
+++ b/src/app/configureApp.jsx
@@ -122,7 +122,7 @@ const routeConfiguration = (siteConfig, componentConfig, placeholderSrc, readMeC
 
     // build raw test pages to maintain modular testing
     if (exampleType === 'tests') {
-      const rawComponentProps = Object.assign({}, componentProps, { pathRoot: '/raw/tests'});
+      const rawComponentProps = Object.assign({}, componentProps, { pathRoot: '/raw/tests' });
       content['/raw/tests'] = {
         path: '/raw/tests',
         component: buildComponent(contentComponent, rawComponentProps),


### PR DESCRIPTION
### Summary
Before in site, the test pages would be stand-alone such that component testing was purely testing the component. We want to maintain this. This adds raw test routes in addition to the navigable test routes.

Additionally,
- Fix incorrect default value for the bidi utility prop
- Sort the found generated-component-config files to keep navigation alphabeticalized

Should be an easier PR to look at 😄 