### PR TITLE
Correcting typo on generate-component-config script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Dynamically builds a react-hash-routed site based on site configuration, navigation configuration and component configuration.
 
 Provides the following script:
-* `generate-compoent-config`: generates the component configuration needed to build the site.
+* `generate-component-config`: generates the component configuration needed to build the site.
 
 Provides the following default configuration:
 * `site.config.js`: must supply the componentConfigPath


### PR DESCRIPTION
### Summary
Minor typo change on the README. (compoent -> component)