### PR TITLE
Use CSS Modules for Site Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updates the site components to use Css Modules
 
 2.0.0-RC.2 - (January 29, 2018)
 ----------

--- a/src/app/common/Placeholder.jsx
+++ b/src/app/common/Placeholder.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
 import Image from 'terra-image';
+import styles from './Placeholder.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
@@ -14,9 +18,9 @@ const defaultProps = {
 };
 
 const Placeholder = ({ src }) => (
-  <div style={{ height: '100%', width: '100%', position: 'relative', padding: '5px' }}>
-    <div style={{ height: '100%', width: '100%', position: 'relative', border: '3px dashed', borderColor: 'lightgrey' }}>
-      <div style={{ position: 'absolute', top: '50%', left: '50%', color: 'grey', transform: 'translate3d(-50%, -50%, 0)' }}>
+  <div className={cx('placeholder')}>
+    <div className={cx('placeholder-container')}>
+      <div className={cx('placeholder-content')}>
         <h3>
           {!!src && <Image variant="rounded" src={src} height="160px" width="160px" isFluid style={{ opacity: '.2' }} />}
         </h3>

--- a/src/app/common/Placeholder.scss
+++ b/src/app/common/Placeholder.scss
@@ -1,0 +1,23 @@
+:local {
+  .placeholder {
+    height: 100%;
+    padding: 5px;
+    position: relative;
+    width: 100%;
+  }
+
+  .placeholder-container {
+    border: 3px dashed;
+    border-color: #d3d3d3;
+    height: 100%;
+    position: relative;
+    width: 100%;
+  }
+
+  .placeholder-content {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+  }
+}

--- a/src/app/components/Components.jsx
+++ b/src/app/components/Components.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
 import { Route, Switch, withRouter } from 'react-router-dom';
+import 'terra-base/lib/baseStyles';
+
 import { siteConfigPropType } from './ComponentsProptypes';
 import ComponentsUtils from './ComponentsUtils';
 import Placeholder from '../common/Placeholder';
+import styles from './Components.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
@@ -66,11 +72,15 @@ class Components extends React.Component {
   render() {
     const { config, exampleType, pathRoot, placeholderSrc } = this.props;
 
+    const componentsClassNames = cx([
+      { 'site-content': pathRoot !== '/raw/tests' },
+    ]);
+
     return (
       <div
-        id="component-content"
+        data-terra-site-content
+        className={componentsClassNames}
         ref={(element) => { this.element = element; }}
-        style={{ height: '100%', position: 'relative', padding: '15px', overflow: 'auto' }}
       >
         <Switch>
           {generateComponentRoutes(config, exampleType, pathRoot, placeholderSrc)}

--- a/src/app/components/Components.jsx
+++ b/src/app/components/Components.jsx
@@ -73,7 +73,8 @@ class Components extends React.Component {
     const { config, exampleType, pathRoot, placeholderSrc } = this.props;
 
     const componentsClassNames = cx([
-      { 'site-content': pathRoot !== '/raw/tests' },
+      'site-content',
+      { 'raw-content': pathRoot === '/raw/tests' },
     ]);
 
     return (

--- a/src/app/components/Components.scss
+++ b/src/app/components/Components.scss
@@ -1,0 +1,8 @@
+:local {
+  .site-content {
+    height: '100%';
+    overflow: 'auto';
+    padding: '15px';
+    position: 'relative';
+  }
+}

--- a/src/app/components/Components.scss
+++ b/src/app/components/Components.scss
@@ -1,8 +1,13 @@
 :local {
   .site-content {
-    height: '100%';
-    overflow: 'auto';
-    padding: '15px';
-    position: 'relative';
+    height: 100%;
+    overflow: auto;
+    padding: 15px;
+    position: relative;
+  }
+
+  .raw-content {
+    height: auto;
+    padding: 0;
   }
 }

--- a/src/app/components/Home.jsx
+++ b/src/app/components/Home.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Markdown from 'terra-markdown';
+import styles from './Home.scss';
 
 const propTypes = {
   /**
@@ -14,7 +15,7 @@ const defaultProps = {
 };
 
 const Home = ({ readMeContent }) => (
-  <div style={{ height: '100%', padding: '15px', overflow: 'auto' }}>
+  <div className={styles.home}>
     <Markdown src={readMeContent} />
   </div>
 );

--- a/src/app/components/Home.scss
+++ b/src/app/components/Home.scss
@@ -1,0 +1,7 @@
+:local {
+  .home {
+    height: '100%';
+    overflow: 'auto';
+    padding: '15px';
+  }
+}


### PR DESCRIPTION
### Summary
This updates the site components to use Css Modules instead of hard-coded styles. 

This also removes padding on raw test pages such that 
1. nightwatch tests that depend on positioning do not need updates
2. wdio screenshots can be 1-to-1 when grabbing the `data-terra-site-content` tag

Closes #6 