### PR TITLE
Update webpack.config to Allow Package-Level Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+- Set the default componentConfigPath to be the default generated-component-config output location.
+
+### Fixed
+- Update webpack.config to allow for package-level testing
 
 2.0.0-RC.2 - (January 29, 2018)
 ----------
@@ -26,7 +31,7 @@ within the terra-core repository to be a package that dynamically builds a react
 configuration, navigation configuration and component configuration.
 
 Provides the following script:
-* generate-compoent-config: generates the component configuration needed to build the site.
+* generate-component-config: generates the component configuration needed to build the site.
 
 Provides the following default configuration:
 * site.config.js: must supply the componentConfigPath

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Provides the following script:
 * `generate-component-config`: generates the component configuration needed to build the site.
 
 Provides the following default configuration:
-* `site.config.js`: must supply the componentConfigPath
+* `site.config.js`
 * `navigation.config.js`
 * `webpack.config.js`
 * `webpack.prod.config.js`

--- a/src/config/site.config.js
+++ b/src/config/site.config.js
@@ -6,7 +6,7 @@ module.exports = {
   navConfig: navigationConfig,
 
   /* The path to the component configuration. */
-  componentConfigPath: undefined,
+  componentConfigPath: './generatedComponentConfig.js',
 
   /* The image to display as page placeholder when a component does not render. */
   placeholderSrc: '',

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -17,7 +17,7 @@ const fs = require('fs');
 const isFile = filePath => (fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory());
 
 const processPath = process.cwd();
-const rootPath = processPath.includes('packages') ? processPath.split(path.sep)[0] : processPath;
+const rootPath = processPath.includes('packages') ? processPath.split('packages')[0] : processPath;
 
 /* Get the site configuration to define as SITE_CONFIG in the DefinePlugin */
 const siteConfigPath = path.resolve(path.join(rootPath, 'site.config.js'));
@@ -98,7 +98,7 @@ const defaultWebpackConfig = {
       chunks: ['babel-polyfill', 'terra-site'],
     }),
     new I18nAggregatorPlugin({
-      baseDirectory: process.cwd(),
+      baseDirectory: rootPath,
       supportedLocales: i18nSupportedLocales,
     }),
     new webpack.DefinePlugin({
@@ -116,18 +116,18 @@ const defaultWebpackConfig = {
   ],
   resolve: {
     extensions: ['.js', '.jsx'],
-    modules: [path.resolve(process.cwd(), 'aggregated-translations'), 'node_modules'],
+    modules: [path.resolve(rootPath, 'aggregated-translations'), 'node_modules'],
 
     // See https://github.com/facebook/react/issues/8026
     alias: {
-      react: path.resolve(process.cwd(), 'node_modules', 'react'),
-      'react-intl': path.resolve(process.cwd(), 'node_modules', 'react-intl'),
-      'react-dom': path.resolve(process.cwd(), 'node_modules', 'react-dom'),
+      react: path.resolve(rootPath, 'node_modules', 'react'),
+      'react-intl': path.resolve(rootPath, 'node_modules', 'react-intl'),
+      'react-dom': path.resolve(rootPath, 'node_modules', 'react-dom'),
     },
   },
   output: {
     filename: '[name].js',
-    path: path.join(process.cwd(), 'dist'),
+    path: path.join(rootPath, 'dist'),
   },
   devtool: 'cheap-source-map',
   devServer: {
@@ -150,7 +150,7 @@ const defaultWebpackConfig = {
     },
   },
   resolveLoader: {
-    modules: [path.resolve(path.join(process.cwd(), 'node_modules'))],
+    modules: [path.resolve(path.join(rootPath, 'node_modules'))],
   },
 };
 

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const isFile = filePath => (fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory());
 
 const processPath = process.cwd();
+/* Get the root path of a mono-repo process call */
 const rootPath = processPath.includes('packages') ? processPath.split('packages')[0] : processPath;
 
 /* Get the site configuration to define as SITE_CONFIG in the DefinePlugin */

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -16,13 +16,16 @@ const fs = require('fs');
 
 const isFile = filePath => (fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory());
 
+const processPath = process.cwd();
+const rootPath = processPath.includes('packages') ? processPath.split(path.sep)[0] : processPath;
+
 /* Get the site configuration to define as SITE_CONFIG in the DefinePlugin */
-const siteConfigPath = path.resolve(path.join(process.cwd(), 'site.config.js'));
+const siteConfigPath = path.resolve(path.join(rootPath, 'site.config.js'));
 // eslint-disable-next-line import/no-dynamic-require
 const siteConfig = isFile(siteConfigPath) ? require(siteConfigPath) : require('./site.config');
 
 /* Get the component configuration to define the COMPONENT_CONFIG_PATH in the DefinePlugin */
-let componentConfigPath = path.resolve(path.join(process.cwd(), siteConfig.componentConfigPath));
+let componentConfigPath = path.resolve(path.join(rootPath, siteConfig.componentConfigPath));
 if (!isFile(componentConfigPath)) {
   componentConfigPath = undefined;
 }


### PR DESCRIPTION
### Summary
- Update webpack.config to allow for package-level testing
- Set the default componentConfigPath to be the default generated-component-config output location.

Closes #5 