### PR TITLE
Update Path Splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased
 * Fix sub navigation creation to check if a a single site page contains additional sub navigation
 * Allow for custom Home pages
 * Update theming-plugin to only output themeable-variables.json in the root directory
+* Fix build script to split on the repository and path separator to ensure the path is split once
 
 ### Removed
 * Remove subtitle site config options to align with the coming Application Name Components

--- a/scripts/generate-component-config/build-component-config.js
+++ b/scripts/generate-component-config/build-component-config.js
@@ -129,8 +129,8 @@ const buildComponentConfig = (foundFiles, repositoryName, outputPathDepth) => {
     };
 
     // Determine if the example needs nested configuration built
-    const packageDirectories = directory.split(packageName)[1].split(path.sep);
-    const sliceAt = (fileType === 'tests' && !monoRepoInstalledAsPackage) || packageName.includes('-site') ? 3 : 2;
+    const packageDirectories = directory.split(packageName + path.sep)[1].split(path.sep);
+    const sliceAt = (fileType === 'tests' && !monoRepoInstalledAsPackage) || packageName.includes('-site') ? 2 : 1;
     const nestedDirectories = packageDirectories.splice(sliceAt, packageDirectories.length);
 
     // Create the example's full configuration


### PR DESCRIPTION
### Summary
When running generate-component-config, the build-component-config will split the path on the package name. When using this with terra-clincial, it actually split the path 2xs, on 'terra-clinical' and 'terra-clincial-site'.

For example taking this path
```
/Users/er047227/terra-clinical/packages/terra-clinical-site/src/examples/action-header/Index.jsx
```
it split it to be:
```
[ '/Users/er047227/',
  '/packages/',
  '-site/src/examples/action-header' ]
```
but the expect output should be
```
[ '/Users/er047227/',
  '/packages/terra-clinical-site/src/examples/action-header' ]
```

This update ensures the path is split 1x on the packageName