### PR TITLE
Expose Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Added
 * Add support in generateComponentConfig for creating configuration from a terra repository that was installed as a package
+* Expose terra-framework-application-header extensions prop. To use this prop, add an extensions key to the navigation object in the navigation.config
 
 ### Changed
 * Update webpack.config to only pass one globally defined DefinePlugin variable

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -145,7 +145,7 @@ class App extends React.Component {
           theme={this.state.theme}
           themes={Object.keys(this.props.themes)}
           onThemeChange={this.handleThemeChange}
-          navigation={matchPath(this.props.location.pathname, this.props.rootPath) ? this.props.navigation : null}
+          navigation={matchPath(this.props.location.pathname, this.props.rootPath) ? this.props.navigation : undefined}
         />
       );
     }

--- a/src/app/ApplicationHeader.jsx
+++ b/src/app/ApplicationHeader.jsx
@@ -162,6 +162,7 @@ class ApplicationHeader extends React.Component {
         )}
         utilities={utility}
         navigation={navTabs}
+        extensions={this.props.navigation.extensions}
         toggle={<Toggle layoutConfig={this.props.layoutConfig} />}
       />
     );

--- a/src/app/configureApp.jsx
+++ b/src/app/configureApp.jsx
@@ -145,7 +145,7 @@ const routeConfiguration = (siteConfig, componentConfig) => {
     },
   };
 
-  const navigationConfig = { index: navigation.index, links: configuredLinks };
+  const navigationConfig = { index: navigation.index, links: configuredLinks, extensions: navigation.extensions };
   const routeConfig = { content, menu };
 
   return { routeConfig, navigation: navigationConfig };


### PR DESCRIPTION
### Summary
The use case for extensions should be to expose external links within the header navigation layout.

Resolves #20 