### PR TITLE
Fix Extensions Error

### DIFF
--- a/src/app/ApplicationHeader.jsx
+++ b/src/app/ApplicationHeader.jsx
@@ -162,7 +162,7 @@ class ApplicationHeader extends React.Component {
         )}
         utilities={utility}
         navigation={navTabs}
-        extensions={this.props.navigation.extensions}
+        extensions={this.props.navigation && this.props.navigation.extensions}
         toggle={<Toggle layoutConfig={this.props.layoutConfig} />}
       />
     );


### PR DESCRIPTION
When rendering the raw route, we don't pass navigation. This results in the following error 

> Cannot read property 'extensions' of undefined.

