### PR TITLE
Minor Changes to generate-components-config Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@ Changelog
 
 Unreleased
 ----------
-### Added
-- Added the `--check-node-modules` flag to the generate-component-config script such that when used it, the search patterns check for terra-repositorys that are installed as packages
-
 ### Fixed
 - Make the generate-component-config script compatible for windows devices
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+- Make the generate-component-config script compatible for windows devices
 
 2.0.0-RC.4 - (Febuary 15, 2018)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Added
+- Added the `--check-node-modules` flag to the generate-component-config script such that when used it, the search patterns check for terra-repositorys that are installed as packages
+
 ### Fixed
 - Make the generate-component-config script compatible for windows devices
 

--- a/scripts/generate-component-config/generate-component-config.js
+++ b/scripts/generate-component-config/generate-component-config.js
@@ -20,6 +20,7 @@ commander
   .option('-o, --output [outputPath]', 'The output location of the generated configuration file', './')
   .option('--no-pages', 'Disable the generation of page example configuration')
   .option('--no-tests', 'Disable the generation of test example configuration')
+  .option('--check-node-modules', 'Determines if the search patterns should check for terra-repos installed as packages')
   .parse(process.argv);
 
 /** Default Search Paths
@@ -35,23 +36,37 @@ commander
  *     dir/packages/ * /examples/ * /test-examples
  */
 const compiledDirPattern = `{examples,${path.join('examples', '*')}}`;
+const terraReposAsPackages = path.join('node_modules', '{terra-core,terra-clinical,terra-framework,terra-consumer}');
 
-let testsSearchPattern;
+// let testsSearchPattern;
+let testsSearchPatternJSX;
+let testsSearchPatternJS;
 if (commander.tests) {
-  testsSearchPattern = path.join('test-examples', '*?(.jsx|.js)');
+  // testsSearchPattern = path.join('test-examples', '*?(.jsx|.js)');
+  testsSearchPatternJSX = path.join('test-examples', '*?(.jsx)');
+  testsSearchPatternJS = path.join('test-examples', '*?(.js)');
 }
 
-let pagesSearchPattern;
+// let pagesSearchPattern;
+let pagesSearchPatternJSX;
+let pagesSearchPatternJS;
 if (commander.pages) {
-  pagesSearchPattern = '*.site-page?(.jsx|.js)';
+  // pagesSearchPattern = '*.site-page?(.jsx|.js)';
+  pagesSearchPatternJSX = '*.site-page?(.jsx)';
+  pagesSearchPatternJS = '*.site-page?(.js)';
 }
 
-const examplesPattern = `{${pagesSearchPattern},${testsSearchPattern}}`;
+const examplesPattern = `{${pagesSearchPatternJS}, ${pagesSearchPatternJSX},${testsSearchPatternJS},${testsSearchPatternJSX}}`;
 
 const defaultSearchPatterns = [
   path.resolve(process.cwd(), `${compiledDirPattern}`, `${examplesPattern}`),
   path.resolve(process.cwd(), 'packages', '*', `${compiledDirPattern}`, `${examplesPattern}`),
 ];
+
+if (commander.checkNodeModules) {
+  defaultSearchPatterns.push(path.resolve(process.cwd(), `${terraReposAsPackages}`, `${compiledDirPattern}`, `${examplesPattern}`));
+  defaultSearchPatterns.push(path.resolve(process.cwd(), `${terraReposAsPackages}`, 'packages', '*', `${compiledDirPattern}`, `${examplesPattern}`));
+}
 
 const searchPaths = defaultSearchPatterns.concat(customSearchPatterns);
 

--- a/scripts/generate-component-config/generate-component-config.js
+++ b/scripts/generate-component-config/generate-component-config.js
@@ -38,25 +38,16 @@ commander
 const compiledDirPattern = `{examples,${path.join('examples', '*')}}`;
 const terraReposAsPackages = path.join('node_modules', '{terra-core,terra-clinical,terra-framework,terra-consumer}');
 
-// let testsSearchPattern;
-let testsSearchPatternJSX;
-let testsSearchPatternJS;
+let testsSearchPattern;
 if (commander.tests) {
-  // testsSearchPattern = path.join('test-examples', '*?(.jsx|.js)');
-  testsSearchPatternJSX = path.join('test-examples', '*?(.jsx)');
-  testsSearchPatternJS = path.join('test-examples', '*?(.js)');
+  testsSearchPattern = `{${path.join('test-examples', '*.jsx')}, ${path.join('test-examples', '*.jsx')}}`;
 }
 
-// let pagesSearchPattern;
-let pagesSearchPatternJSX;
-let pagesSearchPatternJS;
+let pagesSearchPattern;
 if (commander.pages) {
-  // pagesSearchPattern = '*.site-page?(.jsx|.js)';
-  pagesSearchPatternJSX = '*.site-page?(.jsx)';
-  pagesSearchPatternJS = '*.site-page?(.js)';
+  pagesSearchPattern = '{*.site-page.jsx,*.site-page.js}';
 }
-
-const examplesPattern = `{${pagesSearchPatternJS}, ${pagesSearchPatternJSX},${testsSearchPatternJS},${testsSearchPatternJSX}}`;
+const examplesPattern = `{${pagesSearchPattern},${testsSearchPattern}}`;
 
 const defaultSearchPatterns = [
   path.resolve(process.cwd(), `${compiledDirPattern}`, `${examplesPattern}`),

--- a/scripts/generate-component-config/generate-component-config.js
+++ b/scripts/generate-component-config/generate-component-config.js
@@ -20,7 +20,6 @@ commander
   .option('-o, --output [outputPath]', 'The output location of the generated configuration file', './')
   .option('--no-pages', 'Disable the generation of page example configuration')
   .option('--no-tests', 'Disable the generation of test example configuration')
-  .option('--check-node-modules', 'Determines if the search patterns should check for terra-repos installed as packages')
   .parse(process.argv);
 
 /** Default Search Paths
@@ -36,7 +35,6 @@ commander
  *     dir/packages/ * /examples/ * /test-examples
  */
 const compiledDirPattern = `{examples,${path.join('examples', '*')}}`;
-const terraReposAsPackages = path.join('node_modules', '{terra-core,terra-clinical,terra-framework,terra-consumer}');
 
 let testsSearchPattern;
 if (commander.tests) {
@@ -53,11 +51,6 @@ const defaultSearchPatterns = [
   path.resolve(process.cwd(), `${compiledDirPattern}`, `${examplesPattern}`),
   path.resolve(process.cwd(), 'packages', '*', `${compiledDirPattern}`, `${examplesPattern}`),
 ];
-
-if (commander.checkNodeModules) {
-  defaultSearchPatterns.push(path.resolve(process.cwd(), `${terraReposAsPackages}`, `${compiledDirPattern}`, `${examplesPattern}`));
-  defaultSearchPatterns.push(path.resolve(process.cwd(), `${terraReposAsPackages}`, 'packages', '*', `${compiledDirPattern}`, `${examplesPattern}`));
-}
 
 const searchPaths = defaultSearchPatterns.concat(customSearchPatterns);
 


### PR DESCRIPTION
### Summary
- Updates default search patterns to be windows compatible Resolves #8 
- ~Add `--check-node-modules` flag to use the script in repos consuming terra-repositories as packages See #14~ **EDIT:** This issue needs revisited and will not be resolved in this PR.